### PR TITLE
Fix 404 reactive programming link

### DIFF
--- a/_posts/2015-08-22-unidirectional-user-interface-architectures.md
+++ b/_posts/2015-08-22-unidirectional-user-interface-architectures.md
@@ -20,7 +20,7 @@ Architectures might use the term "View" with drastically different connotations.
 
 The DOM and other layers such as frameworks and libraries are assumed to exist between the user and the architecture.
 
-**Ownership of inter-module arrow matters.** `A-->  B` is different than `A  -->B`. The former is Passive programming, while the latter is Reactive programming. Read more [here](http://cycle.js.org/observables.html#reactive-programming).
+**Ownership of inter-module arrow matters.** `A-->  B` is different than `A  -->B`. The former is Passive programming, while the latter is Reactive programming. Read more [here](https://cycle.js.org/streams.html#streams-reactive-programming).
 
 > A unidirectional architecture is said to be **fractal** if subcomponents are structured in the same way as the whole is.
 


### PR DESCRIPTION
When I read to this part, I found the link of reactive programming is 404 now.
I tried to search it from `cycle.js.org`; then I found it's put under `streams` section now.
So, this PR will fix the deprecated url of `reactive programming`.